### PR TITLE
Relax geojson version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "topojson"
 description = "TopoJSON utilities for Rust"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Alex Morega <alex@grep.ro>", "Matthieu Viry <matthieu.viry@cnrs.fr>"]
 license = "MIT"
 repository = "https://github.com/georust/topojson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/georust/topojson"
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geojson = "0.16.0"
+geojson = ">=0.16.0, <0.21.0"
 log = "0.4.0"


### PR DESCRIPTION
Closes #10. I confirmed that the tests pass on all `geojson` versions from 0.16 up until 0.20 (since it hasn't been published yet)