### PR TITLE
Replace Travis with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [nightly, beta, stable]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        geojson_version:
+          - 0.16.0
+          - 0.17.0
+          - 0.18.0
+          - 0.19.0
+          - 0.20.1
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install geojson version ${{ matrix.geojson_version }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+          args: -p geojson --precise ${{ matrix.geojson_version }}
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: rust
-rust:
-  - nightly
-  - beta
-  - stable

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 rust-topojson
 =============
 
-[![Build Status](https://travis-ci.org/georust/topojson.svg)](https://travis-ci.org/georust/topojson)
+[![Build status](https://github.com/georust/topojson/workflows/Test/badge.svg)](https://github.com/georust/topojson/actions?query=workflow%3ATest)
 
 [TopoJSON](https://github.com/topojson/topojson-specification/blob/master/README.md) utilities for Rust
 


### PR DESCRIPTION
Working setup for #12. Looking for feedback on this, and wanted to flag a few things here

* Based on some of the other georust repos I'm only testing on `ubuntu-latest`, but I could add other Windows or MacOS to the build matrix if it's useful
* I added multiple versions of the `geojson` crate to the build matrix for tests based on the conversation in #10 since it's the main dependency here
* I'm checking nightly, beta, and stable Rust in the build step, but not the tests because it would increase the number of combinations significantly. I can change that if it seems worthwhile
* It might also be helpful to run `rustfmt` and `clippy` here, but both of those checks fail now. Would it be best add those in a separate PR where the recommendations are implemented?