### PR TITLE
Add support for geojson 0.23.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
           - 0.20.1
           - 0.21.0
           - 0.22.0
+          - 0.23.0
 
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/georust/topojson"
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geojson = ">=0.16.0, <0.23.0"
+geojson = ">=0.16.0, <0.24.0"
 log = "0.4.0"


### PR DESCRIPTION
Updates the version constraint on `geojson` to allow for version 0.23. I know there's been some conversation on other projects on the correct way of doing version constraints, so I'd be alright with changing this to 0.23.0 if that's the best practice