### PR TITLE
Allow geojson 0.24 to work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
           - 0.21.0
           - 0.22.0
           - 0.23.0
+          - 0.24.0
 
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/georust/topojson"
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geojson = ">=0.16.0, <0.24.0"
+geojson = ">=0.16.0, <=0.24.0"
 log = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/georust/topojson"
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geojson = ">=0.16.0, <=0.24.0"
+geojson = ">=0.16.0, <0.25"
 log = "0.4.0"


### PR DESCRIPTION
I'm just following #20. `cargo test` with 0.24 works fine.