### PR TITLE
Bump upper limit of geojson from 0.24.0 to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,15 @@ name = "topojson"
 description = "TopoJSON utilities for Rust"
 version = "0.5.1"
 edition = "2021"
-authors = ["Alex Morega <alex@grep.ro>", "Matthieu Viry <matthieu.viry@cnrs.fr>"]
+authors = [
+  "Alex Morega <alex@grep.ro>",
+  "Matthieu Viry <matthieu.viry@cnrs.fr>",
+]
 license = "MIT"
 repository = "https://github.com/georust/topojson"
 
 [dependencies]
 serde = "~1.0"
 serde_json = "~1.0"
-geojson = ">=0.16.0, <0.24.0"
+geojson = ">=0.16.0, <0.25.0"
 log = "0.4.0"


### PR DESCRIPTION
This is just a minor change...

geo 0.25.0 can be upgraded without incident.

I am writing [d3_geo_rs](https://crates.io/crates/d3_geo_rs) which also  includes "geo" independently - so my interest here is preventing an enlarged library. For me, this change removes the need for two independent version of rstar and geo to be included. 