### PR TITLE
Minor: Clippy - removed needless borrow.

### DIFF
--- a/src/topology.rs
+++ b/src/topology.rs
@@ -30,11 +30,11 @@ impl<'a> From<&'a TransformParams> for JsonObject {
         let mut map = JsonObject::new();
         map.insert(
             String::from("scale"),
-            ::serde_json::to_value(&transform.scale).unwrap(),
+            ::serde_json::to_value(transform.scale).unwrap(),
         );
         map.insert(
             String::from("translate"),
-            ::serde_json::to_value(&transform.translate).unwrap(),
+            ::serde_json::to_value(transform.translate).unwrap(),
         );
         map
     }


### PR DESCRIPTION
Clippy is slowly improving its ruleset.

I've removed  two examples of this form of warning.

```
warning: the borrowed expression implements the required traits
  --> src/topology.rs:37:36
   |
37 |             ::serde_json::to_value(&transform.translate).unwrap(),
   |                                    ^^^^^^^^^^^^^^^^^^^^ help: change this to: `transform.translate`
```